### PR TITLE
Any address can join their vault

### DIFF
--- a/frontend/src/utils/contracts/getOwnEncryptedPrivateKey.ts
+++ b/frontend/src/utils/contracts/getOwnEncryptedPrivateKey.ts
@@ -14,7 +14,9 @@ const getOwnEncryptedPrivateKey = async (wallet: Wallet, vaultAddress: string, m
 
   const vaultContract = await getVaultContract(wallet, vaultAddress);
 
-  const encryptedPrivateKeyStr = await vaultContract.getOwnEncryptedPrivateKey()
+  const signer = provider.getSigner();
+
+  const encryptedPrivateKeyStr = await vaultContract.connect(signer).getOwnEncryptedPrivateKey()
   if (isBlank(encryptedPrivateKeyStr)) {
     throw new Error(`public key for address ${memberAddress} in vault ${vaultAddress} is blank`)
   }

--- a/frontend/src/utils/contracts/getPublicKey.ts
+++ b/frontend/src/utils/contracts/getPublicKey.ts
@@ -13,7 +13,9 @@ const getPublicKey = async (wallet: Wallet, vaultAddress: string, memberAddress:
 
   const vaultContract = await getVaultContract(wallet, vaultAddress)
 
-  const publicKey = await vaultContract.getPublicKey(memberAddress)
+  const signer = provider.getSigner();
+
+  const publicKey = await vaultContract.connect(signer).getPublicKey(memberAddress)
   if (isBlank(publicKey)) {
     throw new Error(`public key for address ${memberAddress} in ${vaultAddress} is blank`)
   }


### PR DESCRIPTION
Previously, the _getPublicKeys.ts_ and _getOwnEncryptedPrivateKey.ts_ methods weren't connecting the current wallet to the contract calls. Therefore it was defaulting to the address that initially deployed the vault factory contract.